### PR TITLE
feat: extract keyoperations interface to allow pass protowallet as dependency

### DIFF
--- a/auth/utils/create_nonce.go
+++ b/auth/utils/create_nonce.go
@@ -12,7 +12,7 @@ import (
 // CreateNonce generates a cryptographic nonce derived from the wallet
 // The nonce consists of random data combined with an HMAC calculated with the wallet
 // Follows the same pattern as the TypeScript SDK's createNonce function
-func CreateNonce(w wallet.Interface, counterparty wallet.Counterparty) (string, error) {
+func CreateNonce(w wallet.KeyOperations, counterparty wallet.Counterparty) (string, error) {
 	// Generate 16 bytes of random data (matching TypeScript implementation)
 	randomBytes := make([]byte, 16)
 	if _, err := rand.Read(randomBytes); err != nil {

--- a/wallet/interfaces.go
+++ b/wallet/interfaces.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"context"
+
 	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
 )
 
@@ -234,8 +235,20 @@ type ListOutputsResult struct {
 	Outputs      []Output
 }
 
+// KeyOperations defines the interface for cryptographic operations.
+type KeyOperations interface {
+	GetPublicKey(ctx context.Context, args GetPublicKeyArgs, originator string) (*GetPublicKeyResult, error)
+	Encrypt(ctx context.Context, args EncryptArgs, originator string) (*EncryptResult, error)
+	Decrypt(ctx context.Context, args DecryptArgs, originator string) (*DecryptResult, error)
+	CreateHmac(ctx context.Context, args CreateHmacArgs, originator string) (*CreateHmacResult, error)
+	VerifyHmac(ctx context.Context, args VerifyHmacArgs, originator string) (*VerifyHmacResult, error)
+	CreateSignature(ctx context.Context, args CreateSignatureArgs, originator string) (*CreateSignatureResult, error)
+	VerifySignature(ctx context.Context, args VerifySignatureArgs, originator string) (*VerifySignatureResult, error)
+}
+
 // Interface defines the core wallet operations for transaction creation, signing and querying.
 type Interface interface {
+	KeyOperations
 	CreateAction(ctx context.Context, args CreateActionArgs, originator string) (*CreateActionResult, error)
 	SignAction(ctx context.Context, args SignActionArgs, originator string) (*SignActionResult, error)
 	AbortAction(ctx context.Context, args AbortActionArgs, originator string) (*AbortActionResult, error)
@@ -243,15 +256,8 @@ type Interface interface {
 	InternalizeAction(ctx context.Context, args InternalizeActionArgs, originator string) (*InternalizeActionResult, error)
 	ListOutputs(ctx context.Context, args ListOutputsArgs, originator string) (*ListOutputsResult, error)
 	RelinquishOutput(ctx context.Context, args RelinquishOutputArgs, originator string) (*RelinquishOutputResult, error)
-	GetPublicKey(ctx context.Context, args GetPublicKeyArgs, originator string) (*GetPublicKeyResult, error)
 	RevealCounterpartyKeyLinkage(ctx context.Context, args RevealCounterpartyKeyLinkageArgs, originator string) (*RevealCounterpartyKeyLinkageResult, error)
 	RevealSpecificKeyLinkage(ctx context.Context, args RevealSpecificKeyLinkageArgs, originator string) (*RevealSpecificKeyLinkageResult, error)
-	Encrypt(ctx context.Context, args EncryptArgs, originator string) (*EncryptResult, error)
-	Decrypt(ctx context.Context, args DecryptArgs, originator string) (*DecryptResult, error)
-	CreateHmac(ctx context.Context, args CreateHmacArgs, originator string) (*CreateHmacResult, error)
-	VerifyHmac(ctx context.Context, args VerifyHmacArgs, originator string) (*VerifyHmacResult, error)
-	CreateSignature(ctx context.Context, args CreateSignatureArgs, originator string) (*CreateSignatureResult, error)
-	VerifySignature(ctx context.Context, args VerifySignatureArgs, originator string) (*VerifySignatureResult, error)
 	AcquireCertificate(ctx context.Context, args AcquireCertificateArgs, originator string) (*Certificate, error)
 	ListCertificates(ctx context.Context, args ListCertificatesArgs, originator string) (*ListCertificatesResult, error)
 	ProveCertificate(ctx context.Context, args ProveCertificateArgs, originator string) (*ProveCertificateResult, error)


### PR DESCRIPTION
This pull request introduces enhancements to the `auth` and `wallet` packages, focusing on JSON serialization for `AuthMessage`, improved cryptographic operations abstraction, and interface refactoring to streamline code reuse. The most significant changes include adding custom JSON marshaling/unmarshaling for `AuthMessage`, introducing a `KeyOperations` interface for cryptographic functions, and updating the `CreateNonce` function to use the new interface.

### Enhancements to JSON Serialization:
* Added `MarshalJSON` and `UnmarshalJSON` methods to the `AuthMessage` type in `auth/types.go` for custom JSON serialization. These methods handle encoding/decoding of `IdentityKey`, `Payload`, and `Signature` fields using Base64 and DER formats.

### Cryptographic Operations Abstraction:
* Introduced a new `KeyOperations` interface in `wallet/interfaces.go` to encapsulate cryptographic operations such as key management, encryption, HMAC creation/verification, and signature handling.
* Updated the `Interface` in `wallet/interfaces.go` to embed `KeyOperations`, removing duplicate cryptographic methods from the wallet interface.

### Refactoring for Code Reuse:
* Refactored the `CreateNonce` function in `auth/utils/create_nonce.go` to use the new `KeyOperations` interface instead of the previous `wallet.Interface`. This improves modularity and aligns with the updated interface structure.

### Import Adjustments:
* Added necessary imports for `base64` and `json` in `auth/types.go` to support the new JSON serialization methods.
* Organized imports in `wallet/interfaces.go` to include the `ec` package for cryptographic operations.